### PR TITLE
Fix crash when pressing 'e' without selecting a vulnerability

### DIFF
--- a/grummage.py
+++ b/grummage.py
@@ -122,6 +122,10 @@ class Grummage(App):
         self.sbom_file = sbom_file
         self.vulnerability_report = None
         self.debug_log_file = open("debug_log.txt", "w")
+        self.selected_vuln_id = None
+        self.selected_package_name = None
+        self.selected_package_version = None
+        self.detailed_text = None
 
     def quit(self):
         """Exit the application."""


### PR DESCRIPTION
Fixes #16

## Changes

Initialize `selected_vuln_id`, `selected_package_name`, `selected_package_version`, and `detailed_text` attributes to `None` in `__init__`.

## Problem

When the user pressed 'e' to explain a vulnerability before selecting any node in the tree view, grummage would crash with an `AttributeError` because these attributes were not defined.

## Solution

By initializing these attributes to `None` in the constructor, the existing check on line 460:
```python
if key == "e" and self.selected_vuln_id and self.detailed_text:
```
now works correctly - when no vulnerability is selected, the condition evaluates to `False` and the explain action is skipped without crashing.

## Testing

Tested by launching grummage and pressing 'e' immediately without selecting any vulnerability. The application no longer crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)