### PR TITLE
Fix SBOM encoding error on Windows

### DIFF
--- a/grummage.py
+++ b/grummage.py
@@ -436,7 +436,7 @@ class Grummage(App):
     def load_json(self, file_path):
         """Load SBOM JSON from a file."""
         try:
-            with open(file_path, "r") as file:
+            with open(file_path, "r", encoding="utf-8") as file:
                 return json.load(file)
         except Exception as e:
             self.debug_log(f"Error loading SBOM JSON: {e}")


### PR DESCRIPTION
Fixes #14

## Summary
Adds explicit UTF-8 encoding when opening SBOM JSON files, resolving encoding errors on Windows systems.

## Changes
- Modified `load_json()` in grummage.py to specify `encoding="utf-8"` parameter
- Single line change for cross-platform compatibility

## Technical Details
- Windows defaults to cp1252 encoding, which cannot properly read UTF-8 encoded JSON files
- UTF-8 is the standard encoding for JSON per RFC 8259
- This fix works across all platforms (Windows, Linux, macOS)
- Maintains backward compatibility with existing SBOM files

## Testing
User should test with UTF-8 encoded SBOM files on Windows to verify the fix resolves the encoding error.

Co-Authored-By: Jim Harbin <jharbin>