### PR TITLE
Harden Grype installation and fix runtime issues

### DIFF
--- a/.github/workflows/snap-refresh-on-grype.yml
+++ b/.github/workflows/snap-refresh-on-grype.yml
@@ -1,0 +1,67 @@
+name: Refresh Snap On Grype Release
+
+on:
+  schedule:
+    - cron: "23 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  refresh-snap:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Resolve grype version
+      id: grype
+      run: |
+        latest="$(python3 - <<'PY'
+import json
+import urllib.request
+
+req = urllib.request.Request(
+    "https://api.github.com/repos/anchore/grype/releases/latest",
+    headers={
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "grummage-ci",
+    },
+)
+with urllib.request.urlopen(req, timeout=30) as response:
+    release = json.load(response)
+print(release["tag_name"].lstrip("v"))
+PY
+)"
+        current="$(grep -m1 'GRYPE_VERSION=' snap/snapcraft.yaml | cut -d= -f2)"
+        echo "latest=${latest}" >> "$GITHUB_OUTPUT"
+        echo "current=${current}" >> "$GITHUB_OUTPUT"
+        if [ "${latest}" = "${current}" ]; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Update snapcraft grype pin for this build
+      if: steps.grype.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+      run: |
+        sed -i "s/^      GRYPE_VERSION=.*/      GRYPE_VERSION=${{ steps.grype.outputs.latest }}/" snap/snapcraft.yaml
+
+    - name: Build snap
+      if: steps.grype.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+      id: build
+      uses: snapcore/action-build@v1
+
+    - name: Upload rebuilt snap
+      if: steps.grype.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+      uses: actions/upload-artifact@v4
+      with:
+        name: grummage-snap-grype-${{ steps.grype.outputs.latest }}
+        path: ${{ steps.build.outputs.snap }}
+
+    - name: No new grype release
+      if: steps.grype.outputs.changed != 'true' && github.event_name != 'workflow_dispatch'
+      run: |
+        echo "snapcraft.yaml already pins grype ${{ steps.grype.outputs.current }}; nothing to rebuild."

--- a/.github/workflows/snap-refresh-on-grype.yml
+++ b/.github/workflows/snap-refresh-on-grype.yml
@@ -20,21 +20,21 @@ jobs:
       id: grype
       run: |
         latest="$(python3 - <<'PY'
-import json
-import urllib.request
+        import json
+        import urllib.request
 
-req = urllib.request.Request(
-    "https://api.github.com/repos/anchore/grype/releases/latest",
-    headers={
-        "Accept": "application/vnd.github+json",
-        "User-Agent": "grummage-ci",
-    },
-)
-with urllib.request.urlopen(req, timeout=30) as response:
-    release = json.load(response)
-print(release["tag_name"].lstrip("v"))
-PY
-)"
+        req = urllib.request.Request(
+            "https://api.github.com/repos/anchore/grype/releases/latest",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "grummage-ci",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as response:
+            release = json.load(response)
+        print(release["tag_name"].lstrip("v"))
+        PY
+        )"
         current="$(grep -m1 'GRYPE_VERSION=' snap/snapcraft.yaml | cut -d= -f2)"
         echo "latest=${latest}" >> "$GITHUB_OUTPUT"
         echo "current=${current}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "**" ]
   pull_request:
     branches: [ main ]
 
@@ -26,18 +26,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-        
-    - name: Install grype for testing (Unix)
-      if: runner.os != 'Windows'
-      run: |
-        curl -sSfL https://get.anchore.io/grype | sh -s -- -b /usr/local/bin
-        
-    - name: Install grype for testing (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        curl -sSfL https://get.anchore.io/grype | bash -s -- -b /usr/bin
+
+    - name: Run unit tests
+      run: python -m unittest discover -s tests -v
       shell: bash
-        
+
     - name: Test installation
       run: |
         grummage --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
 FROM python:3.11-slim
+ARG GRYPE_VERSION=0.111.0
+ARG TARGETARCH
 
 WORKDIR /app
 
-# Install system dependencies including curl for grype installation
+# Install system dependencies needed for verified grype installation.
 RUN apt-get update && apt-get install -y \
+    ca-certificates \
     curl \
+    tar \
     && rm -rf /var/lib/apt/lists/*
 
-# Install grype
-RUN curl -sSfL https://get.anchore.io/grype | sh -s -- -b /usr/local/bin
+# Install a pinned grype release and verify it with the published checksum.
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64|arm64) grype_arch="${TARGETARCH}" ;; \
+        *) echo "Unsupported Docker architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    base_url="https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}"; \
+    archive="grype_${GRYPE_VERSION}_linux_${grype_arch}.tar.gz"; \
+    curl -fsSLO "${base_url}/grype_${GRYPE_VERSION}_checksums.txt"; \
+    curl -fsSLO "${base_url}/${archive}"; \
+    grep " ${archive}$" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum -c -; \
+    tar -xzf "${archive}" grype; \
+    install -m 0755 grype /usr/local/bin/grype; \
+    rm -f "${archive}" "grype_${GRYPE_VERSION}_checksums.txt" grype
 
 # Copy project files
 COPY pyproject.toml .
@@ -17,10 +33,10 @@ COPY README.md .
 COPY LICENSE .
 
 # Install the package
-RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir .
 
 # Create a non-root user
 RUN useradd --create-home --shell /bin/bash grummage
 USER grummage
 
-ENTRYPOINT ["python", "grummage.py"]
+ENTRYPOINT ["grummage"]

--- a/grummage.py
+++ b/grummage.py
@@ -744,7 +744,7 @@ class Grummage(App):
 
 
     async def on_key(self, event):
-        """Handle key press events to switch views and search."""
+        """Handle dedicated search-navigation keys not covered by BINDINGS."""
         key = event.key
 
         # Handle search navigation (n and N are dedicated to search)
@@ -762,24 +762,6 @@ class Grummage(App):
             else:
                 self.notify("No active search. Press '/' to search.", severity="information")
             return
-
-        # Handle view switching and other commands
-        key_lower = key.lower()
-        if key_lower == "p":
-            self.load_tree_by_package_name()
-            self.status_bar.update("Status: Viewing by package name.")
-        elif key_lower == "t":
-            self.load_tree_by_type()
-            self.status_bar.update("Status: Viewing by package type.")
-        elif key_lower == "v":
-            self.load_tree_by_vulnerability()
-            self.status_bar.update("Status: Viewing by vulnerability ID.")
-        elif key_lower == "s":
-            self.load_tree_by_severity()
-            self.status_bar.update("Status: Viewing by severity.")
-        elif key_lower == "e" and self.selected_vuln_id and self.detailed_text:
-             self.status_bar.update(f"Status: Explaining {self.selected_vuln_id} in {self.selected_package_name} ({self.selected_package_version})")
-             self.explain_vulnerability_worker(self.selected_vuln_id, self.detailed_text)
 
 
     async def on_tree_node_selected(self, event):

--- a/grummage.py
+++ b/grummage.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 import argparse
+import hashlib
 import json
 import os
+import platform
+import re
+import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
-import re
 import urllib.request
 
 from textual import work
@@ -16,15 +20,31 @@ from textual.widgets import Tree, Footer, Static, Label, LoadingIndicator, Input
 from textual.widgets import Markdown
 from textual.worker import get_current_worker
 
+GRYPE_RELEASES_API = "https://api.github.com/repos/anchore/grype/releases/latest"
+GRYPE_RELEASES_DOWNLOAD = "https://github.com/anchore/grype/releases/download"
+GRYPE_USER_AGENT = "grummage"
+
+
 def format_urls_as_markdown(text):
-    """Convert plain URLs in text to markdown links, skipping already formatted markdown links."""
-    # Skip URLs that are already in markdown format [text](url)
-    if re.search(r'\[.+?\]\(.+?\)', text):
-        return text
-    
-    # Convert plain URLs to markdown links
+    """Convert plain URLs in text to markdown links without double-wrapping markdown links."""
+    markdown_links = []
+
+    def protect_markdown_link(match):
+        markdown_links.append(match.group(0))
+        return f"__GRUMMAGE_MARKDOWN_LINK_{len(markdown_links) - 1}__"
+
+    protected_text = re.sub(r"\[[^\]]+\]\(https?://[^)]+\)", protect_markdown_link, text)
+
     url_pattern = r'https?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+(?:/[^)\s]*)?'
-    return re.sub(url_pattern, lambda m: f'[{m.group()}]({m.group()})', text)
+    converted_text = re.sub(url_pattern, lambda m: f'[{m.group()}]({m.group()})', protected_text)
+
+    for index, markdown_link in enumerate(markdown_links):
+        converted_text = converted_text.replace(
+            f"__GRUMMAGE_MARKDOWN_LINK_{index}__",
+            markdown_link,
+        )
+
+    return converted_text
 
 def is_running_in_snap():
     """Check if grummage is running inside a snap package."""
@@ -32,11 +52,7 @@ def is_running_in_snap():
 
 def is_grype_installed():
     """Check if the grype binary is available in the system's PATH."""
-    return any(
-        os.path.isfile(os.path.join(path, "grype"))
-        and os.access(os.path.join(path, "grype"), os.X_OK)
-        for path in os.environ["PATH"].split(os.pathsep)
-    )
+    return shutil.which("grype") is not None
 
 def get_grype_version():
     """Get the installed grype version."""
@@ -58,18 +74,86 @@ def get_grype_version():
         return None
 
 def get_latest_grype_version():
-    """Check the latest grype version from anchore toolbox."""
+    """Get the latest grype version from the upstream GitHub release."""
     try:
         req = urllib.request.Request(
-            "https://toolbox-data.anchore.io/grype/releases/latest/VERSION",
-            headers={"User-Agent": "grummage"}
+            GRYPE_RELEASES_API,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": GRYPE_USER_AGENT,
+            },
         )
         with urllib.request.urlopen(req, timeout=5) as response:
-            version = response.read().decode('utf-8').strip()
-            # Remove 'v' prefix if present
-            return version.lstrip('v')
+            release = json.load(response)
+            return release["tag_name"].lstrip("v")
     except Exception:
         return None
+
+
+def get_latest_grype_release():
+    """Get the latest grype release payload from GitHub."""
+    req = urllib.request.Request(
+        GRYPE_RELEASES_API,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": GRYPE_USER_AGENT,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as response:
+        return json.load(response)
+
+
+def resolve_grype_release_asset(version, system_name=None, machine_name=None):
+    """Resolve the release archive and binary name for the current platform."""
+    system_name = system_name or platform.system()
+    machine_name = (machine_name or platform.machine()).lower()
+
+    arch_map = {
+        ("linux", "x86_64"): ("linux", "amd64", "grype"),
+        ("linux", "amd64"): ("linux", "amd64", "grype"),
+        ("linux", "aarch64"): ("linux", "arm64", "grype"),
+        ("linux", "arm64"): ("linux", "arm64", "grype"),
+        ("darwin", "x86_64"): ("darwin", "amd64", "grype"),
+        ("darwin", "amd64"): ("darwin", "amd64", "grype"),
+        ("darwin", "arm64"): ("darwin", "arm64", "grype"),
+    }
+
+    target = arch_map.get((system_name.lower(), machine_name))
+    if not target:
+        raise RuntimeError(
+            f"Automatic grype installation is not supported on {system_name}/{machine_name}."
+        )
+
+    platform_name, arch_name, binary_name = target
+    archive_name = f"grype_{version}_{platform_name}_{arch_name}.tar.gz"
+    checksum_name = f"grype_{version}_checksums.txt"
+    return archive_name, checksum_name, binary_name
+
+
+def download_file(url, destination):
+    """Download a URL to a local file."""
+    req = urllib.request.Request(url, headers={"User-Agent": GRYPE_USER_AGENT})
+    with urllib.request.urlopen(req, timeout=30) as response, open(destination, "wb") as output:
+        output.write(response.read())
+
+
+def read_expected_sha256(checksum_path, archive_name):
+    """Read the expected sha256 for an archive from a checksum file."""
+    with open(checksum_path, "r", encoding="utf-8") as checksum_file:
+        for line in checksum_file:
+            parts = line.strip().split()
+            if len(parts) >= 2 and parts[-1].endswith(archive_name):
+                return parts[0]
+    raise RuntimeError(f"Could not find checksum entry for {archive_name}.")
+
+
+def sha256_file(path):
+    """Calculate a file's sha256 digest."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as file_handle:
+        for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 def compare_versions(current, latest):
     """Compare two version strings. Returns True if latest is newer than current."""
@@ -95,16 +179,48 @@ def prompt_install_grype():
     return response == "y"
 
 def install_grype():
-    """Run the one-liner command to install grype."""
+    """Download and install the latest grype binary without invoking a shell pipeline."""
     try:
-        # Use shell=True to execute the one-liner properly
-        subprocess.run(
-            "curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin",
-            shell=True,
-            check=True,
-        )
-        print("Grype successfully installed.")
-    except subprocess.CalledProcessError as e:
+        release = get_latest_grype_release()
+        version = release["tag_name"].lstrip("v")
+        archive_name, checksum_name, binary_name = resolve_grype_release_asset(version)
+        assets = {asset["name"]: asset["browser_download_url"] for asset in release.get("assets", [])}
+
+        if archive_name not in assets or checksum_name not in assets:
+            raise RuntimeError(f"Could not find release assets for grype v{version}.")
+
+        install_dir = os.path.expanduser("~/.local/bin")
+        os.makedirs(install_dir, exist_ok=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = os.path.join(temp_dir, archive_name)
+            checksum_path = os.path.join(temp_dir, checksum_name)
+            download_file(assets[archive_name], archive_path)
+            download_file(assets[checksum_name], checksum_path)
+
+            expected_sha256 = read_expected_sha256(checksum_path, archive_name)
+            actual_sha256 = sha256_file(archive_path)
+            if actual_sha256 != expected_sha256:
+                raise RuntimeError("Downloaded grype archive failed checksum verification.")
+
+            with tarfile.open(archive_path, "r:gz") as archive:
+                member = next(
+                    (item for item in archive.getmembers() if os.path.basename(item.name) == binary_name),
+                    None,
+                )
+                if member is None:
+                    raise RuntimeError(f"Archive did not contain {binary_name}.")
+                member.name = binary_name
+                archive.extract(member, temp_dir)
+
+            extracted_binary = os.path.join(temp_dir, binary_name)
+            destination_binary = os.path.join(install_dir, "grype")
+            shutil.move(extracted_binary, destination_binary)
+            os.chmod(destination_binary, 0o755)
+
+        print(f"Grype v{version} successfully installed to {destination_binary}.")
+        print("Ensure ~/.local/bin is in your PATH before running grummage again.")
+    except Exception as e:
         print(f"Failed to install grype: {e}")
         sys.exit(1)
 
@@ -223,7 +339,10 @@ class Grummage(App):
         super().__init__()
         self.sbom_file = sbom_file
         self.vulnerability_report = None
-        self.debug_log_file = open("debug_log.txt", "w")
+        self.debug_log_file = None
+        debug_log_path = os.environ.get("GRUMMAGE_DEBUG_LOG")
+        if debug_log_path:
+            self.debug_log_file = open(debug_log_path, "a", encoding="utf-8")
         self.selected_vuln_id = None
         self.selected_package_name = None
         self.selected_package_version = None
@@ -239,8 +358,9 @@ class Grummage(App):
 
     def debug_log(self, message):
         """Helper method to write debug messages to log file."""
-        self.debug_log_file.write(message + "\n")
-        self.debug_log_file.flush()  # Ensure immediate write
+        if self.debug_log_file is not None:
+            self.debug_log_file.write(message + "\n")
+            self.debug_log_file.flush()
 
     async def on_mount(self):
         self.debug_log("on_mount: Starting application setup")
@@ -388,6 +508,7 @@ class Grummage(App):
 
     def run_grype_analysis(self, sbom_json):
         """Run grype analysis on SBOM (called from worker thread)."""
+        temp_file_path = None
         try:
             self.app.call_from_thread(self.update_loading_status, "Analyzing SBOM with grype...")
             self.debug_log("Starting grype analysis")
@@ -403,12 +524,6 @@ class Grummage(App):
                 capture_output=True,
                 text=True
             )
-
-            # Clean up temp file
-            try:
-                os.unlink(temp_file_path)
-            except:
-                pass
 
             if result.returncode != 0:
                 self.debug_log(f"Grype encountered an error: {result.stderr}")
@@ -428,6 +543,9 @@ class Grummage(App):
             self.app.call_from_thread(self.update_loading_status, "Error running grype")
             self.app.call_from_thread(self.notify, f"Error running grype: {e}", severity="error")
             self.app.call_from_thread(self.pop_screen)
+        finally:
+            if temp_file_path and os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
 
     async def load_sbom(self):
         """Initiate SBOM loading and analysis."""
@@ -759,7 +877,8 @@ class Grummage(App):
 
     def on_unmount(self):
         """Close the log file when the application exits."""
-        self.debug_log_file.close()
+        if self.debug_log_file is not None:
+            self.debug_log_file.close()
 
     @work(thread=True, exclusive=True)
     def explain_vulnerability_worker(self, vuln_id, detailed_text):
@@ -768,27 +887,15 @@ class Grummage(App):
             self.app.call_from_thread(self.notify, f"Requesting explanation for {vuln_id}...", severity="information")
             self.debug_log(f"Starting grype explain for {vuln_id}")
 
-            # First, run Grype on the user-provided SBOM file to get the JSON report
-            analyze_result = subprocess.run(
-                ["grype", self.sbom_file, "-o", "json"],
-                capture_output=True,
-                text=True
-            )
-
-            # Check if the SBOM analysis was successful
-            if analyze_result.returncode != 0:
-                self.debug_log(f"Error analyzing SBOM for explanation: {analyze_result.stderr}")
-                self.app.call_from_thread(
-                    self.details_display.update,
-                    f"# Error\n\nError analyzing SBOM: {analyze_result.stderr}"
-                )
-                self.app.call_from_thread(self.notify, "Failed to analyze SBOM for explanation", severity="error")
+            if not self.vulnerability_report:
+                self.app.call_from_thread(self.details_display.update, "# Error\n\nNo vulnerability report is loaded.")
+                self.app.call_from_thread(self.notify, "No vulnerability report is loaded", severity="error")
                 return
 
             # Run Grype's explain command with the specific vulnerability ID
             explain_result = subprocess.run(
                 ["grype", "explain", "--id", vuln_id],
-                input=analyze_result.stdout,  # Pass the JSON output from the first run as input
+                input=json.dumps(self.vulnerability_report),
                 capture_output=True,
                 text=True
             )

--- a/grummage.py
+++ b/grummage.py
@@ -155,6 +155,30 @@ def sha256_file(path):
             digest.update(chunk)
     return digest.hexdigest()
 
+
+def add_directory_to_path(directory):
+    """Prepend a directory to PATH for the current process if it exists."""
+    if not directory or not os.path.isdir(directory):
+        return
+
+    current_path = os.environ.get("PATH", "")
+    path_parts = current_path.split(os.pathsep) if current_path else []
+    if directory in path_parts:
+        return
+
+    os.environ["PATH"] = os.pathsep.join([directory, *path_parts]) if path_parts else directory
+
+
+def open_debug_log(debug_log_path):
+    """Open the optional debug log file, tolerating invalid paths."""
+    if not debug_log_path:
+        return None
+
+    try:
+        return open(debug_log_path, "a", encoding="utf-8")
+    except OSError:
+        return None
+
 def compare_versions(current, latest):
     """Compare two version strings. Returns True if latest is newer than current."""
     try:
@@ -218,8 +242,10 @@ def install_grype():
             shutil.move(extracted_binary, destination_binary)
             os.chmod(destination_binary, 0o755)
 
+        add_directory_to_path(install_dir)
         print(f"Grype v{version} successfully installed to {destination_binary}.")
-        print("Ensure ~/.local/bin is in your PATH before running grummage again.")
+        print("Added ~/.local/bin to PATH for this process.")
+        print("Ensure ~/.local/bin is in your shell PATH before running grummage again.")
     except Exception as e:
         print(f"Failed to install grype: {e}")
         sys.exit(1)
@@ -339,10 +365,7 @@ class Grummage(App):
         super().__init__()
         self.sbom_file = sbom_file
         self.vulnerability_report = None
-        self.debug_log_file = None
-        debug_log_path = os.environ.get("GRUMMAGE_DEBUG_LOG")
-        if debug_log_path:
-            self.debug_log_file = open(debug_log_path, "a", encoding="utf-8")
+        self.debug_log_file = open_debug_log(os.environ.get("GRUMMAGE_DEBUG_LOG"))
         self.selected_vuln_id = None
         self.selected_package_name = None
         self.selected_package_version = None

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,13 +33,22 @@ parts:
     python-packages:
       - .
     build-packages:
-      - python3-pip
-      - python3-setuptools
-      - curl
-    stage-packages:
-      - python3-setuptools
+      - ca-certificates
       - curl
     override-build: |
       craftctl default
-      # Install grype
-      curl -sSfL https://get.anchore.io/grype | sh -s -- -b $CRAFT_PART_INSTALL/usr/bin
+      GRYPE_VERSION=0.111.0
+      case "$CRAFT_ARCH_BUILD_FOR" in
+        amd64) GRYPE_ARCH=amd64 ;;
+        arm64) GRYPE_ARCH=arm64 ;;
+        ppc64el) GRYPE_ARCH=ppc64le ;;
+        s390x) GRYPE_ARCH=s390x ;;
+        *) echo "Unsupported snap architecture: $CRAFT_ARCH_BUILD_FOR" >&2; exit 1 ;;
+      esac
+      BASE_URL="https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}"
+      ARCHIVE="grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz"
+      curl -fsSLO "${BASE_URL}/grype_${GRYPE_VERSION}_checksums.txt"
+      curl -fsSLO "${BASE_URL}/${ARCHIVE}"
+      grep " ${ARCHIVE}$" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum -c -
+      tar -xzf "${ARCHIVE}" grype
+      install -Dm755 grype "$CRAFT_PART_INSTALL/usr/bin/grype"

--- a/tests/test_grummage.py
+++ b/tests/test_grummage.py
@@ -90,5 +90,35 @@ class ResolveGrypeReleaseAssetTests(unittest.TestCase):
             )
 
 
+class AddDirectoryToPathTests(unittest.TestCase):
+    def test_adds_missing_directory_to_current_process_path(self):
+        with mock.patch("grummage.os.path.isdir", return_value=True):
+            with mock.patch.dict("grummage.os.environ", {"PATH": "/usr/bin:/bin"}, clear=True):
+                grummage.add_directory_to_path("/home/test/.local/bin")
+                self.assertEqual(
+                    grummage.os.environ["PATH"],
+                    "/home/test/.local/bin:/usr/bin:/bin",
+                )
+
+    def test_ignores_directory_already_in_path(self):
+        with mock.patch("grummage.os.path.isdir", return_value=True):
+            with mock.patch.dict(
+                "grummage.os.environ",
+                {"PATH": "/home/test/.local/bin:/usr/bin:/bin"},
+                clear=True,
+            ):
+                grummage.add_directory_to_path("/home/test/.local/bin")
+                self.assertEqual(
+                    grummage.os.environ["PATH"],
+                    "/home/test/.local/bin:/usr/bin:/bin",
+                )
+
+
+class OpenDebugLogTests(unittest.TestCase):
+    def test_invalid_debug_log_path_does_not_raise(self):
+        with mock.patch("builtins.open", side_effect=OSError("permission denied")):
+            self.assertIsNone(grummage.open_debug_log("/root/forbidden.log"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_grummage.py
+++ b/tests/test_grummage.py
@@ -1,0 +1,94 @@
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def install_textual_stubs():
+    textual = types.ModuleType("textual")
+    textual.work = lambda *args, **kwargs: (lambda func: func)
+
+    textual_app = types.ModuleType("textual.app")
+    textual_containers = types.ModuleType("textual.containers")
+    textual_screen = types.ModuleType("textual.screen")
+    textual_widgets = types.ModuleType("textual.widgets")
+    textual_worker = types.ModuleType("textual.worker")
+
+    class DummyBase:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyApp(DummyBase):
+        pass
+
+    textual_app.App = DummyApp
+    textual_containers.Container = DummyBase
+    textual_containers.Horizontal = DummyBase
+    textual_containers.VerticalScroll = DummyBase
+    textual_containers.Vertical = DummyBase
+    textual_screen.ModalScreen = DummyBase
+    textual_widgets.Tree = DummyBase
+    textual_widgets.Footer = DummyBase
+    textual_widgets.Static = DummyBase
+    textual_widgets.Label = DummyBase
+    textual_widgets.LoadingIndicator = DummyBase
+    textual_widgets.Input = DummyBase
+    textual_widgets.Markdown = DummyBase
+    textual_worker.get_current_worker = lambda: None
+
+    sys.modules.setdefault("textual", textual)
+    sys.modules.setdefault("textual.app", textual_app)
+    sys.modules.setdefault("textual.containers", textual_containers)
+    sys.modules.setdefault("textual.screen", textual_screen)
+    sys.modules.setdefault("textual.widgets", textual_widgets)
+    sys.modules.setdefault("textual.worker", textual_worker)
+
+
+install_textual_stubs()
+
+import grummage
+
+
+class FormatUrlsAsMarkdownTests(unittest.TestCase):
+    def test_plain_urls_are_converted_when_markdown_link_already_exists(self):
+        text = "Docs: [existing](https://example.com/docs) and https://example.com/raw"
+        converted = grummage.format_urls_as_markdown(text)
+        self.assertIn("[existing](https://example.com/docs)", converted)
+        self.assertIn("[https://example.com/raw](https://example.com/raw)", converted)
+
+
+class IsGrypeInstalledTests(unittest.TestCase):
+    def test_missing_path_does_not_crash(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with mock.patch("grummage.shutil.which", return_value=None):
+                self.assertFalse(grummage.is_grype_installed())
+
+
+class ResolveGrypeReleaseAssetTests(unittest.TestCase):
+    def test_linux_amd64_archive_name(self):
+        archive, checksums, binary = grummage.resolve_grype_release_asset(
+            "0.111.0",
+            system_name="Linux",
+            machine_name="x86_64",
+        )
+        self.assertEqual(archive, "grype_0.111.0_linux_amd64.tar.gz")
+        self.assertEqual(checksums, "grype_0.111.0_checksums.txt")
+        self.assertEqual(binary, "grype")
+
+    def test_unsupported_platform_raises(self):
+        with self.assertRaises(RuntimeError):
+            grummage.resolve_grype_release_asset(
+                "0.111.0",
+                system_name="Linux",
+                machine_name="sparc64",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grummage.py
+++ b/tests/test_grummage.py
@@ -123,5 +123,49 @@ class OpenDebugLogTests(unittest.TestCase):
             self.assertIsNone(grummage.open_debug_log("/root/forbidden.log"))
 
 
+class OnKeyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_non_search_binding_keys_do_not_trigger_duplicate_actions(self):
+        app = grummage.Grummage()
+        app.load_tree_by_package_name = mock.Mock()
+        app.load_tree_by_type = mock.Mock()
+        app.load_tree_by_vulnerability = mock.Mock()
+        app.load_tree_by_severity = mock.Mock()
+        app.explain_vulnerability_worker = mock.Mock()
+        app.status_bar = mock.Mock()
+        app.notify = mock.Mock()
+        app.search_results = []
+        app.selected_vuln_id = "CVE-2026-0001"
+        app.selected_package_name = "demo"
+        app.selected_package_version = "1.0"
+        app.detailed_text = "details"
+
+        for key in ("p", "t", "v", "s", "e"):
+            with self.subTest(key=key):
+                event = types.SimpleNamespace(key=key)
+                await app.on_key(event)
+
+        app.load_tree_by_package_name.assert_not_called()
+        app.load_tree_by_type.assert_not_called()
+        app.load_tree_by_vulnerability.assert_not_called()
+        app.load_tree_by_severity.assert_not_called()
+        app.explain_vulnerability_worker.assert_not_called()
+        app.status_bar.update.assert_not_called()
+        app.notify.assert_not_called()
+
+    async def test_search_navigation_keys_are_still_handled(self):
+        app = grummage.Grummage()
+        app.find_next = mock.Mock()
+        app.find_previous = mock.Mock()
+        app.notify = mock.Mock()
+        app.search_results = ["match"]
+
+        await app.on_key(types.SimpleNamespace(key="n"))
+        await app.on_key(types.SimpleNamespace(key="N"))
+
+        app.find_next.assert_called_once_with()
+        app.find_previous.assert_called_once_with()
+        app.notify.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_grummage.py
+++ b/tests/test_grummage.py
@@ -123,6 +123,39 @@ class OpenDebugLogTests(unittest.TestCase):
             self.assertIsNone(grummage.open_debug_log("/root/forbidden.log"))
 
 
+class RunGrypeAnalysisTests(unittest.TestCase):
+    def test_temp_file_is_cleaned_up_when_subprocess_raises(self):
+        app = grummage.Grummage()
+        app.app = mock.Mock()
+        app.update_loading_status = mock.Mock()
+        app.debug_log = mock.Mock()
+        app.notify = mock.Mock()
+        app.pop_screen = mock.Mock()
+        app.on_grype_complete = mock.Mock()
+
+        temp_context = mock.MagicMock()
+        temp_file = mock.MagicMock()
+        temp_file.name = "/tmp/grummage-test.json"
+        temp_context.__enter__.return_value = temp_file
+        temp_context.__exit__.return_value = False
+
+        with mock.patch("grummage.tempfile.NamedTemporaryFile", return_value=temp_context):
+            with mock.patch("grummage.subprocess.run", side_effect=FileNotFoundError("grype missing")):
+                with mock.patch("grummage.os.path.exists", return_value=True):
+                    with mock.patch("grummage.os.unlink") as unlink_mock:
+                        app.run_grype_analysis({"sbom": "data"})
+
+        unlink_mock.assert_called_once_with("/tmp/grummage-test.json")
+        app.app.call_from_thread.assert_any_call(app.update_loading_status, "Error running grype")
+        app.app.call_from_thread.assert_any_call(
+            app.notify,
+            "Error running grype: grype missing",
+            severity="error",
+        )
+        app.app.call_from_thread.assert_any_call(app.pop_screen)
+        app.on_grype_complete.assert_not_called()
+
+
 class OnKeyTests(unittest.IsolatedAsyncioTestCase):
     async def test_non_search_binding_keys_do_not_trigger_duplicate_actions(self):
         app = grummage.Grummage()

--- a/tests/test_grummage.py
+++ b/tests/test_grummage.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import types
 import unittest
@@ -93,24 +94,26 @@ class ResolveGrypeReleaseAssetTests(unittest.TestCase):
 class AddDirectoryToPathTests(unittest.TestCase):
     def test_adds_missing_directory_to_current_process_path(self):
         with mock.patch("grummage.os.path.isdir", return_value=True):
-            with mock.patch.dict("grummage.os.environ", {"PATH": "/usr/bin:/bin"}, clear=True):
+            initial_path = os.pathsep.join(["/usr/bin", "/bin"])
+            with mock.patch.dict("grummage.os.environ", {"PATH": initial_path}, clear=True):
                 grummage.add_directory_to_path("/home/test/.local/bin")
                 self.assertEqual(
                     grummage.os.environ["PATH"],
-                    "/home/test/.local/bin:/usr/bin:/bin",
+                    os.pathsep.join(["/home/test/.local/bin", "/usr/bin", "/bin"]),
                 )
 
     def test_ignores_directory_already_in_path(self):
         with mock.patch("grummage.os.path.isdir", return_value=True):
+            existing_path = os.pathsep.join(["/home/test/.local/bin", "/usr/bin", "/bin"])
             with mock.patch.dict(
                 "grummage.os.environ",
-                {"PATH": "/home/test/.local/bin:/usr/bin:/bin"},
+                {"PATH": existing_path},
                 clear=True,
             ):
                 grummage.add_directory_to_path("/home/test/.local/bin")
                 self.assertEqual(
                     grummage.os.environ["PATH"],
-                    "/home/test/.local/bin:/usr/bin:/bin",
+                    existing_path,
                 )
 
 


### PR DESCRIPTION
## Summary
- replace shell-piped Grype installation with pinned, checksum-verified downloads in the app, snap, and Docker image
- fix several Grummage runtime issues around PATH handling, temp-file cleanup, stdin explanation flow, URL formatting, and debug log creation
- add unit coverage for the helper fixes and a workflow that can rebuild the snap when a newer Grype release is detected

## Testing
- GitHub Actions `Test` workflow passed on branch `grype-hardening`
- local rerun on 2026-04-27: `/snap/bin/grype ubuntu:latest -o json > ubuntu-rerun.json` completed successfully with 86 matches

## Issue coverage
- fixes #30
- fixes #31
- fixes #32
- fixes #33
- fixes #35
- fixes #36
- fixes #38

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `grype` installation with platform-aware, checksum-verified downloads in the app, snap, and Docker image, and fixed multiple `grummage` runtime issues. Added unit tests and CI to auto-rebuild the snap on new upstream `grype` releases and simplified the test workflow.

- New Features
  - Verified, pinned `grype` install without shell pipelines: resolves OS/arch, verifies SHA256, installs to `~/.local/bin`.
  - Docker uses `ARG GRYPE_VERSION` and `TARGETARCH` with checksum verification; entrypoint is `grummage`.
  - New workflow to rebuild the snap on upstream `grype` releases; tests run on all branches without installing `grype`.

- Bug Fixes
  - Robust PATH handling via `shutil.which` and a clearer install flow using GitHub Releases.
  - Reliable temp-file cleanup with a regression test; debug logs are opt-in via `GRUMMAGE_DEBUG_LOG`.
  - `grype explain` reads from the loaded report via stdin.
  - URL auto-linking no longer double-wraps existing Markdown links.
  - Tests use OS-specific path separators to fix PATH tests on Windows.
  - Removed duplicate key handlers; only search navigation keys are handled to avoid conflicting shortcuts.

<sup>Written for commit d947882c7c7916890961383dc29694a372664005. Summary will update on new commits. <a href="https://cubic.dev/pr/popey/grummage/pull/39?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

