### PR TITLE
fix: use gpt-5-mini model for repo-assist workflow

### DIFF
--- a/.github/workflows/repo-assist.lock.yml
+++ b/.github/workflows/repo-assist.lock.yml
@@ -167,7 +167,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
+          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'gpt-5-mini' }}
           GH_AW_INFO_VERSION: "1.0.55"
           GH_AW_INFO_AGENT_VERSION: "1.0.55"
           GH_AW_INFO_CLI_VERSION: "v0.77.5"
@@ -1212,7 +1212,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'gpt-5-mini' }}
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1760,7 +1760,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'gpt-5-mini' }}
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.77.5

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -1,4 +1,6 @@
 ---
+engine: copilot
+model: gpt-5-mini
 description: |
   A friendly repository assistant that runs regularly (twice a day by default) to assist maintainers.
   Can also be triggered on-demand via '/repo-assist <instructions>' to perform specific tasks.


### PR DESCRIPTION
## Summary

- Replaces `claude-sonnet-4.6` (unsupported by this Copilot subscription tier) with `gpt-5-mini` as the fallback model in the repo-assist workflow
- Updates all three occurrences in `repo-assist.lock.yml` (`GH_AW_INFO_MODEL` + both `COPILOT_MODEL` env vars)
- Adds `engine: copilot` and `model: gpt-5-mini` to the `repo-assist.md` source frontmatter

Closes #41

## Test plan

- [ ] Merge and confirm the next scheduled repo-assist run completes without a "Model Not Supported" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the repo-assist workflow to `gpt-5-mini` as the Copilot model, replacing unsupported `claude-sonnet-4.6` to stop “Model Not Supported” failures. Aligns the workflow with our Copilot plan and addresses #41.

- **Bug Fixes**
  - Set fallback model to `gpt-5-mini` in `.github/workflows/repo-assist.lock.yml` for `GH_AW_INFO_MODEL` and both `COPILOT_MODEL` env vars.
  - Added `engine: copilot` and `model: gpt-5-mini` to `.github/workflows/repo-assist.md` frontmatter.

<sup>Written for commit f45b0e55f98966a6fca7492e29e60613882018e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/grummage/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

