### PR TITLE
fix(ci): add GH_TOKEN to repo-assist pre-activation check

### DIFF
--- a/.github/workflows/repo-assist.lock.yml
+++ b/.github/workflows/repo-assist.lock.yml
@@ -1874,6 +1874,8 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" != "schedule" ]]; then exit 0; fi
           COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --search 'in:title "[repo-assist]"' --json number --jq 'length')
           [[ "$COUNT" -lt "$MAX_OPEN_PRS" ]]
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   push_repo_memory:
     needs:

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -37,6 +37,8 @@ on:
         COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --search 'in:title "[repo-assist]"' --json number --jq 'length')
         [[ "$COUNT" -lt "$MAX_OPEN_PRS" ]]
       # exits 0 if not scheduled or <MAX_OPEN_PRS open PRs, 1 if ≥MAX_OPEN_PRS
+      env:
+        GH_TOKEN: ${{ github.token }}
 
 if: needs.pre_activation.outputs.check_result == 'success'
 


### PR DESCRIPTION
## Summary

- The repo-assist scheduled workflow was failing at the `pre_activation` job's `check` step with exit code 4
- The `gh pr list` command requires `GH_TOKEN` to be set in the environment when running in GitHub Actions — it wasn't

## Changes

- Add `GH_TOKEN: ${{ github.token }}` to the `check` step env in both `repo-assist.md` (source) and `repo-assist.lock.yml` (compiled)

## Testing

- Verified against the failed run: https://github.com/popey/grummage/actions/runs/26890727371/job/79315666697
- Next scheduled run should pass the pre-activation check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `GH_TOKEN: ${{ github.token }}` in the repo-assist workflow’s pre-activation check so `gh pr list` can run in GitHub Actions. This fixes the exit code 4 failure and unblocks scheduled runs.

<sup>Written for commit eecdbe93a827322a7c1b2bfcc4ae467e05843eb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/grummage/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

