### PR TITLE
[repo-assist] Fix simulate_key action

### DIFF
--- a/grummage.py
+++ b/grummage.py
@@ -880,6 +880,38 @@ class Grummage(App):
         )
         self.debug_log(f"Navigated to search result {self.search_index + 1}/{len(self.search_results)}")
 
+    def action_simulate_key(self, key_name):
+        """Simulate simple navigation keys (used by BINDINGS). Non-fatal if Tree API varies between Textual versions."""
+        try:
+            if not hasattr(self, "tree_view") or self.tree_view is None:
+                return
+
+            # Down / Up navigation
+            if key_name == "down":
+                if hasattr(self.tree_view, "select_next"):
+                    self.tree_view.select_next()
+                elif hasattr(self.tree_view, "cursor_down"):
+                    self.tree_view.cursor_down()
+                return
+            if key_name == "up":
+                if hasattr(self.tree_view, "select_previous"):
+                    self.tree_view.select_previous()
+                elif hasattr(self.tree_view, "cursor_up"):
+                    self.tree_view.cursor_up()
+                return
+
+            # Left/Right - collapse/expand current node when possible
+            sel = getattr(self.tree_view, "selected_node", None)
+            if sel is None:
+                return
+            if key_name == "left" and hasattr(sel, "collapse"):
+                sel.collapse()
+            elif key_name == "right" and hasattr(sel, "expand"):
+                sel.expand()
+
+        except Exception as e:
+            self.debug_log(f"simulate_key action error: {e}")
+
     def on_unmount(self):
         """Close the log file when the application exits."""
         if self.debug_log_file is not None:

--- a/grummage.py
+++ b/grummage.py
@@ -901,7 +901,9 @@ class Grummage(App):
                 return
 
             # Left/Right - collapse/expand current node when possible
-            sel = getattr(self.tree_view, "selected_node", None)
+            sel = getattr(self.tree_view, "cursor_node", None)
+            if sel is None:
+                sel = getattr(self.tree_view, "selected_node", None)
             if sel is None:
                 return
             if key_name == "left" and hasattr(sel, "collapse"):

--- a/tests/test_grummage.py
+++ b/tests/test_grummage.py
@@ -200,5 +200,36 @@ class OnKeyTests(unittest.IsolatedAsyncioTestCase):
         app.notify.assert_not_called()
 
 
+class SimulateKeyTests(unittest.TestCase):
+    def test_left_collapses_cursor_node(self):
+        app = grummage.Grummage()
+        cursor_node = mock.Mock()
+        app.tree_view = types.SimpleNamespace(cursor_node=cursor_node)
+
+        app.action_simulate_key("left")
+
+        cursor_node.collapse.assert_called_once_with()
+        cursor_node.expand.assert_not_called()
+
+    def test_right_expands_cursor_node(self):
+        app = grummage.Grummage()
+        cursor_node = mock.Mock()
+        app.tree_view = types.SimpleNamespace(cursor_node=cursor_node)
+
+        app.action_simulate_key("right")
+
+        cursor_node.expand.assert_called_once_with()
+        cursor_node.collapse.assert_not_called()
+
+    def test_left_falls_back_to_selected_node(self):
+        app = grummage.Grummage()
+        selected_node = mock.Mock()
+        app.tree_view = types.SimpleNamespace(cursor_node=None, selected_node=selected_node)
+
+        app.action_simulate_key("left")
+
+        selected_node.collapse.assert_called_once_with()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #37

Adds action_simulate_key to Grummage to handle simulate_key bindings without error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `action_simulate_key` to `Grummage` to support `simulate_key` bindings and prevent navigation errors when the `Tree` API varies between Textual versions. Now prefers `cursor_node` for left/right and falls back to `selected_node`.

- **Bug Fixes**
  - Up/down navigation via `select_next`/`cursor_down` and `select_previous`/`cursor_up`.
  - Left/right uses `cursor_node` first, falls back to `selected_node`; collapses/expands when available.
  - Safe no-op if `tree_view` or methods are missing; logs exceptions instead of crashing.

<sup>Written for commit 2dfe2abc7e0881336d7e4e36069f46bff02803ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/grummage/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

